### PR TITLE
api version changed from 2026-04 to 2026-07

### DIFF
--- a/src/GraphqlService.php
+++ b/src/GraphqlService.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Client;
 
 class GraphqlService
 {
-    private const API_VERSION = '2026-04';
+    private const API_VERSION = '2026-07';
     private const MAX_IMAGES = 250;
     private const MAX_IMAGES_UPDATE = 240;
     private const ONLINE_STORE_PUBLICATION = 'Online Store';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Shopify GraphQL API version to 2026-07 for improved compatibility with the latest platform API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->